### PR TITLE
More options for caching configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ $ tox
 
 ### v0.4.dev
 * Add support for parametrized queries.
+* More options for cache configuration.
 * Allow to override configuration of the Athena class after it is initialized.
 * Refactored implementation from layered decorators to one class using specialized  helpers.
 

--- a/src/pallas/facade.py
+++ b/src/pallas/facade.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import copy
 import time
 from typing import Iterable, Optional
 
@@ -193,6 +194,31 @@ class Athena:
     @property
     def cache(self) -> AthenaCache:
         return self._cache
+
+    def using(
+        self,
+        *,
+        cache_enabled: Optional[bool] = None,
+        cache_read: Optional[bool] = None,
+        cache_write: Optional[bool] = None,
+    ) -> Athena:
+        """
+        Crate a new instance with updated configuration.
+
+        :param cache_enabled: Set to False to disable caching completely.
+        :param cache_read: Set to False to disable reading the cache.
+        :param cache_write: Set to False to disable writing the cache.
+        :return: an update copy of this instance
+        """
+        other = copy.copy(self)
+        other._cache = copy.copy(self._cache)
+        if cache_enabled is not None:
+            other._cache.enabled = cache_enabled
+        if cache_read is not None:
+            other._cache.read = cache_read
+        if cache_write is not None:
+            other._cache.write = cache_write
+        return other
 
     def submit(
         self,

--- a/src/pallas/facade.py
+++ b/src/pallas/facade.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import copy
 import time
+import warnings
 from typing import Iterable, Optional
 
 from pallas.caching import AthenaCache
@@ -238,12 +239,19 @@ class Athena:
             Can contain %s or %(key)s placeholders for substitution by *parameters*
         :param parameters: parameters to substitute in *operation*.
             All parameters are quoted appropriately.
-        :param ignore_cache: do not load cached results
+        :param ignore_cache: deprecated, do not use
         :return: a query instance
         """
+        if ignore_cache:
+            warnings.warn(
+                "The athena.submit(..., ignore_cache=True) parameter is deprecated."
+                " Use athena.using(cache_read=False).submit(...) instead.",
+                FutureWarning,
+            )
+            return self.using(cache_read=False).submit(operation, parameters)
         sql = self._get_sql(operation, parameters)
         should_cache = is_select(sql)
-        if should_cache and not ignore_cache:
+        if should_cache:
             execution_id = self._cache.load_execution_id(self.database, sql)
             if execution_id is not None:
                 return self.get_query(execution_id)
@@ -283,10 +291,20 @@ class Athena:
 
         This is a blocking method that waits until query finishes.
 
-        :param sql: SQL query to be executed
-        :param ignore_cache: do not load cached results
+        :param operation: an SQL query to be executed
+            Can contain %s or %(key)s placeholders for substitution by *parameters*
+        :param parameters: parameters to substitute in *operation*.
+            All parameters are quoted appropriately.
+        :param ignore_cache: deprecated, do not use
         :return: query results
         """
+        if ignore_cache:
+            warnings.warn(
+                "The athena.execute(..., ignore_cache=True) parameter is deprecated."
+                " Use athena.using(cache_read=False).execute(...) instead.",
+                FutureWarning,
+            )
+            return self.using(cache_read=False).execute(operation, parameters)
         return self.submit(
             operation, parameters, ignore_cache=ignore_cache
         ).get_results()

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -152,7 +152,8 @@ class TestAthenaCache:
         """Test that cache is unique to a query."""
         athena.execute("SELECT 1 id, 'foo' name")  # fill cache
         fake.request_log.clear()
-        results = athena.execute("SELECT 1 id, 'foo' name", ignore_cache=True)
+        with pytest.warns(FutureWarning):
+            results = athena.execute("SELECT 1 id, 'foo' name", ignore_cache=True)
         assert fake.request_log == [
             "StartQueryExecution",
             "GetQueryExecution",
@@ -220,7 +221,8 @@ class TestAthenaCache:
         """Test that cache read can be skipped."""
         athena.submit("SELECT 1 id, 'foo' name")
         fake.request_log.clear()
-        athena.submit("SELECT 1 id, 'foo' name", ignore_cache=True)
+        with pytest.warns(FutureWarning):
+            athena.submit("SELECT 1 id, 'foo' name", ignore_cache=True)
         assert fake.request_log == ["StartQueryExecution"]
         assert storage.size() == 1
 

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -74,6 +74,20 @@ class TestAthena:
         query = athena.submit(" SELECT 1 ")
         assert query.get_info().sql == " SELECT 1 "
 
+    def test_using(self, athena):
+        other_athena = athena.using(cache_enabled=False)
+        assert other_athena.cache.enabled is False
+        assert other_athena.cache.read is True
+        assert other_athena.cache.write is True
+        other_athena = athena.using(cache_read=False)
+        assert other_athena.cache.enabled is True
+        assert other_athena.cache.read is False
+        assert other_athena.cache.write is True
+        other_athena = athena.using(cache_write=False)
+        assert other_athena.cache.enabled is True
+        assert other_athena.cache.read is True
+        assert other_athena.cache.write is False
+
 
 class TestQuery:
     def test_repr(self, athena):


### PR DESCRIPTION

```python
# To disable cache permanently
athena.cache.enabled = False
# To disable cache for one query
athena.using(cache_enabled=False).execute(...)
# Read but not write
athena.using(cache_write=False).execute(...)
# Write but not read
athena.using(cache_read=False).execute(...)
```