### PR TITLE
Fix query execution ID not cached locally when cached remotely

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 v0.8.dev
 --------
 
-...
+* Fix query execution ID not cached locally when cached remotely.
 
 
 v0.7 (2020-08-31)

--- a/src/pallas/caching.py
+++ b/src/pallas/caching.py
@@ -213,6 +213,7 @@ class AthenaCache:
             return execution_id
         execution_id = _load_execution_id(self.remote_storage, database, sql)
         if execution_id is not None:
+            _save_execution_id(self.local_storage, database, sql, execution_id)
             return execution_id
         return None
 


### PR DESCRIPTION
When query execution ID was loaded from a remote cache (S3), it was not stored to locally.