### PR TITLE
Failed or cancelled queries found in cached are ignored.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 
 v0.10.dev
 ---------
-Nothing yet.
+
+* Failed or cancelled queries found in cached are ignored.
+  Export ``PALLAS_CACHE_FAILED=true`` to use failed queries from the cache.
 
 
 v0.9 (2021-03-03)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -52,6 +52,8 @@ All arguments are optional.
         cache_remote="s3://...",
         # Optional query result cache.
         cache_local="~/Notebooks/.cache/",
+        # Whether to return failed queries from cache. Defaults to False.
+        cache_failed=False,
         # Normalize white whitespace for better caching. Enabled by default.
         normalize=True,
         # Kill queries on KeybordInterrupt. Enabled by default.
@@ -73,6 +75,7 @@ corresponding to arguments in the previous example:
     export PALLAS_KILL_ON_INTERRUPT=true
     export PALLAS_CACHE_REMOTE=$PALLAS_OUTPUT_LOCATION
     export PALLAS_CACHE_LOCAL=~/Notebooks/.cache/
+    export PALLAS_CACHE_FAILED=false
 
 
 .. code-block:: python
@@ -157,6 +160,7 @@ After the initialization, caching can be customized later using the :attr:`.Athe
     athena.cache.write = True  # Can be set to False to read but not write the cache
     athena.cache.local = "~/Notebooks/.cache/"
     athena.cache.remote = "s3://..."
+    athena.cache.failed = True
 
 Alternatively, the :meth:`.Athena.using` method can override a configuration
 for selected queries only:

--- a/src/pallas/assembly.py
+++ b/src/pallas/assembly.py
@@ -23,6 +23,7 @@ import os
 import sys
 from typing import Mapping, Optional, TextIO, Union
 
+from pallas.caching import AthenaCache
 from pallas.client import Athena
 from pallas.proxies import Boto3Proxy
 
@@ -64,8 +65,9 @@ def setup(
     output_location: Optional[str] = None,
     cache_local: Optional[str] = None,
     cache_remote: Optional[str] = None,
-    normalize: bool = True,
-    kill_on_interrupt: bool = True,
+    cache_failed: bool = AthenaCache.failed,
+    normalize: bool = Athena.normalize,
+    kill_on_interrupt: bool = Athena.kill_on_interrupt,
 ) -> Athena:
     """
     Setup an :class:`.Athena` client.
@@ -86,6 +88,7 @@ def setup(
         Both results and query execution IDs are stored in the local cache.
     :param cache_remote: an URI of a remote cache.
         Query execution IDs without results are stored in the remote cache.
+    :param cache_failed: whether to cache failed queries
     :param normalize: whether to normalize queries before execution.
     :param kill_on_interrupt: whether to kill queries on KeyboardInterrupt.
     :return: a new instance of Athena client
@@ -95,6 +98,7 @@ def setup(
         athena.cache.local = cache_local
     if cache_remote is not None:
         athena.cache.remote = cache_remote
+    athena.cache.failed = cache_failed
     athena.database = database
     athena.workgroup = workgroup
     athena.output_location = output_location
@@ -138,8 +142,11 @@ def environ_setup(
         region=config.get_str("REGION"),
         cache_remote=config.get_str("CACHE_REMOTE"),
         cache_local=config.get_str("CACHE_LOCAL"),
-        normalize=config.get_bool("NORMALIZE", True),
-        kill_on_interrupt=config.get_bool("KILL_ON_INTERRUPT", True),
+        cache_failed=config.get_bool("CACHE_FAILED", AthenaCache.failed),
+        normalize=config.get_bool("NORMALIZE", Athena.normalize),
+        kill_on_interrupt=config.get_bool(
+            "KILL_ON_INTERRUPT", Athena.kill_on_interrupt
+        ),
     )
 
 

--- a/src/pallas/assembly.py
+++ b/src/pallas/assembly.py
@@ -88,7 +88,7 @@ def setup(
         Both results and query execution IDs are stored in the local cache.
     :param cache_remote: an URI of a remote cache.
         Query execution IDs without results are stored in the remote cache.
-    :param cache_failed: whether to cache failed queries
+    :param cache_failed: whether to return failed queries found in cache.
     :param normalize: whether to normalize queries before execution.
     :param kill_on_interrupt: whether to kill queries on KeyboardInterrupt.
     :return: a new instance of Athena client

--- a/src/pallas/caching.py
+++ b/src/pallas/caching.py
@@ -164,7 +164,7 @@ class AthenaCache:
     #: Can be updated to reconfigure the caching.
     write: bool = True
 
-    #: Whether to cache failed queries.
+    #: Whether to return failed queries found in cache.
     #:
     #: When this is false, failed queries found in cache are ignored.
     failed: bool = False

--- a/src/pallas/caching.py
+++ b/src/pallas/caching.py
@@ -151,18 +151,23 @@ class AthenaCache:
 
     #: Can be set to False to disable caching completely.
     #:
-    #: Can be update to enable or disable the caching.
+    #: Can be updated to enable or disable the caching.
     enabled: bool = True
 
     #: Can be set to False to disable reading the cache.
     #:
-    #: Can be update to reconfigure the caching.
+    #: Can be updated to reconfigure the caching.
     read: bool = True
 
     #: Can be set to False to disable writing the cache.
     #:
-    #: Can be update to reconfigure the caching.
+    #: Can be updated to reconfigure the caching.
     write: bool = True
+
+    #: Whether to cache failed queries.
+    #:
+    #: When this is false, failed queries found in cache are ignored.
+    failed: bool = False
 
     @property
     def local(self) -> Optional[str]:

--- a/src/pallas/client.py
+++ b/src/pallas/client.py
@@ -270,7 +270,7 @@ class Athena:
         :param cache_enabled: whether a cache should be used.
         :param cache_read: whether a cache should be read.
         :param cache_write: whether a cache should be written.
-        :param cache_failed: whether to cache failed queries.
+        :param cache_failed: whether to return failed queries found in cache.
         :return: an updated copy of this client
         """
         other = copy.copy(self)

--- a/src/pallas/testing.py
+++ b/src/pallas/testing.py
@@ -39,11 +39,13 @@ class FakeProxy(AthenaProxy):
 
     _sql: Dict[str, str]
     _results: Dict[str, QueryResults]
+    _states: Dict[str, str]
     _request_log: List[str]
 
     def __init__(self) -> None:
         self._sql = {}
         self._results = {}
+        self._states = {}
         self._request_log = []
 
     @property
@@ -62,6 +64,7 @@ class FakeProxy(AthenaProxy):
         results = self._fake_query_results()
         self._sql[execution_id] = sql
         self._results[execution_id] = results
+        self._states[execution_id] = self.state
         return execution_id
 
     def get_query_execution(self, execution_id: str) -> QueryInfo:
@@ -74,7 +77,7 @@ class FakeProxy(AthenaProxy):
 
     def stop_query_execution(self, execution_id: str) -> None:
         self._request_log.append("StopQueryExecution")
-        self.state = "CANCELLED"
+        self._states[execution_id] = "CANCELLED"
 
     def _fake_query_info(self, execution_id: str, sql: str) -> QueryInfo:
         data = {
@@ -83,7 +86,7 @@ class FakeProxy(AthenaProxy):
             "ResultConfiguration": {"OutputLocation": ...},
             "QueryExecutionContext": {},
             "Status": {
-                "State": self.state,
+                "State": self._states[execution_id],
                 "SubmissionDateTime": ...,
                 "CompletionDateTime": ...,
             },

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -31,6 +31,7 @@ class TestSetup:
         assert athena.kill_on_interrupt is True
         assert athena.cache.local is None
         assert athena.cache.remote is None
+        assert athena.cache.failed is False
 
     def test_do_not_normalize(self):
         athena = setup(normalize=False)
@@ -78,3 +79,11 @@ class TestSetup:
         )
         assert athena.cache.local == "file:/path/"
         assert athena.cache.remote == "s3://bucket/path/"
+
+    def test_cache_failed(self):
+        athena = setup(cache_failed=True)
+        assert athena.cache.failed is True
+
+    def test_cache_failed_from_env(self):
+        athena = environ_setup(environ={"PALLAS_CACHE_FAILED": "true"})
+        assert athena.cache.failed is True

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from pallas import Athena
+from pallas import Athena, AthenaQueryError
 from pallas.storage.memory import MemoryStorage
 from pallas.testing import FakeProxy
 
@@ -175,7 +175,7 @@ class TestAthenaCache:
         assert_query_results(results)
         assert storage.size() == 0
 
-    def test_execute_second_query_different_sql(self, athena, fake, storage):
+    def test_execute_second_query_different_sql(self, athena, fake):
         """Test that cache is unique to a query."""
         athena.execute("SELECT 1 id, 'foo' name")  # fill cache
         fake.request_log.clear()
@@ -188,13 +188,29 @@ class TestAthenaCache:
         ]
         assert_another_query_results(results)
 
-    def test_execute_second_query_different_database(self, athena, fake, storage):
+    def test_execute_second_query_different_database(self, athena, fake):
         """Test that cache is unique to a database."""
         athena.execute("SELECT 1 id, 'foo' name")  # fill cache
         fake.request_log.clear()
         athena.database = "other"
         results = athena.execute("SELECT 1 id, 'foo' name")
         assert fake.request_log == [
+            "StartQueryExecution",
+            "GetQueryExecution",
+            "GetQueryResults",
+        ]
+        assert_query_results(results)
+
+    def test_execute_second_query_first_failed(self, athena, fake):
+        """Test failed queries in cache are ignored."""
+        fake.state = "FAILED"
+        with pytest.raises(AthenaQueryError):
+            athena.execute("SELECT 1 id, 'foo' name")
+        fake.request_log.clear()
+        fake.state = "SUCCEEDED"
+        results = athena.execute("SELECT 1 id, 'foo' name")
+        assert fake.request_log == [
+            "GetQueryExecution",
             "StartQueryExecution",
             "GetQueryExecution",
             "GetQueryResults",
@@ -220,7 +236,9 @@ class TestAthenaCache:
         athena.submit("SELECT 1 id, 'foo' name")
         fake.request_log.clear()
         athena.submit("SELECT 1 id, 'foo' name")
-        assert fake.request_log == []
+        assert fake.request_log == [
+            "GetQueryExecution",  # Check that the cached query did not fail.
+        ]
         assert storage.size() == 1
 
     def test_submit_second_query_not_select(self, athena, fake, storage):
@@ -239,6 +257,18 @@ class TestAthenaCache:
         athena.submit("SELECT 2 id, 'bar' name")
         assert fake.request_log == ["StartQueryExecution"]
         assert storage.size() == 2
+
+    def test_submit_second_query_first_failed(self, athena, fake):
+        """Test that failed failed queries in are ignored."""
+        fake.state = "FAILED"
+        athena.submit("SELECT 1 id, 'foo' name")
+        fake.state = "SUCCEEDED"
+        fake.request_log.clear()
+        athena.submit("SELECT 1 id, 'foo' name")
+        assert fake.request_log == [
+            "GetQueryExecution",  # Discover that the cached query failed.
+            "StartQueryExecution",  # Start a new one.
+        ]
 
     # Test athena.get_query() method
 
@@ -342,8 +372,8 @@ class TestAthenaCache:
     def test_remote_get_results_second_query_same_sql(self, remote_athena, fake):
         """Test getting results query in cache results not cached."""
         remote_athena.execute("SELECT 1 id, 'foo' name")
-        second_query = remote_athena.submit("SELECT 1 id, 'foo' name")
         fake.request_log.clear()
+        second_query = remote_athena.submit("SELECT 1 id, 'foo' name")
         second_query_results = second_query.get_results()
         assert fake.request_log == [
             "GetQueryExecution",
@@ -364,8 +394,8 @@ class TestAthenaCache:
     def test_local_get_uncached_results_second_query_same_sql(self, local_athena, fake):
         """Test that the second query downloads data if the first does not."""
         local_athena.submit("SELECT 1 id, 'foo' name")  # Does not download results.
-        second_query = local_athena.submit("SELECT 1 id, 'foo' name")
         fake.request_log.clear()
+        second_query = local_athena.submit("SELECT 1 id, 'foo' name")
         second_query_results = second_query.get_results()
         assert fake.request_log == [
             "GetQueryExecution",
@@ -410,8 +440,8 @@ class TestAthenaCache:
     def test_remote_join_second_query_query_same_sql(self, remote_athena, fake):
         """Test waiting for a query cached results not cached."""
         remote_athena.execute("SELECT 1 id, 'foo' name")
-        second_query = remote_athena.submit("SELECT 1 id, 'foo' name")
         fake.request_log.clear()
+        second_query = remote_athena.submit("SELECT 1 id, 'foo' name")
         second_query.join()
         assert fake.request_log == ["GetQueryExecution"]
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -201,7 +201,7 @@ class TestAthenaCache:
         ]
         assert_query_results(results)
 
-    def test_execute_second_query_first_failed(self, athena, fake):
+    def test_execute_failed_not_cached(self, athena, fake):
         """Test failed queries in cache are ignored."""
         fake.state = "FAILED"
         with pytest.raises(AthenaQueryError):
@@ -216,6 +216,17 @@ class TestAthenaCache:
             "GetQueryResults",
         ]
         assert_query_results(results)
+
+    def test_execute_failed_cached(self, athena, fake):
+        """Test failed queries can be cached if desired."""
+        athena.cache.failed = True
+        fake.state = "FAILED"
+        with pytest.raises(AthenaQueryError):
+            athena.execute("SELECT 1 id, 'foo' name")
+        fake.request_log.clear()
+        with pytest.raises(AthenaQueryError):
+            athena.execute("SELECT 1 id, 'foo' name")
+        assert fake.request_log == ["GetQueryExecution"]
 
     # Test athena.submit() method
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,9 +125,9 @@ class TestQuery:
 
     def test_get_info_twice_not_finished(self, athena, fake):
         """Test that query info is not cached when query not finished."""
+        fake.state = "RUNNING"
         query = athena.submit("SELECT 1")
         fake.request_log.clear()
-        fake.state = "RUNNING"
         query.get_info()
         query.get_info()
         assert fake.request_log == ["GetQueryExecution", "GetQueryExecution"]


### PR DESCRIPTION
Until this PR, all queries were cached even if they finished with an error. When some error was caused by some background configuration (e.g. AWS permissions), it was not easy to retry because Pallas returned cached error even when a cause was fixed.

After this change, Pallas ignores fails and cancelled queries found in cache. This implementation is necessary because the queries are written to the cache before their result status is known.

It is possible to export `PALLAS_CACHE_FAILED=true` to returned cached failures as before. That can be useful to avoid large bills when a failing query is retried again and again. Cached cancelled queries are always ignored.